### PR TITLE
Add anaconda channel

### DIFF
--- a/SpecterEnv.yml
+++ b/SpecterEnv.yml
@@ -1,5 +1,6 @@
 name: SpecterEnv
 channels:
+  - anaconda
   - blaze
   - bioconda
   - defaults


### PR DESCRIPTION
The anaconda channel contains asn1crypto / py27 under linux64. Installation fails otherwise (on debian stretch) with message:
NoPackagesFoundError: Package missing in current linux-64 channels: 
  - asn1crypto 0.24.0 py27_0